### PR TITLE
add benchmarks for conjunctions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,19 @@ BenchmarkListComprehensionShort1-16     	  110869	     55206 ns/op
 PASS
 ok  	github.com/harpratap/cue-perf-tests	33.884s
 ```
+
+## 2. Conjunctions
+
+Conjunctions are like AND operators used for specifying multiple constraints. But using too many constraints slows down the export timings too. Meaning `#level1 & { text1: text2: "hello" }` is less costly than `#level1 & { text1: #level2 & { text2: "hello" }` even though both behave exactly the same.
+
+```
+go test -bench=BenchmarkConjunction -benchtime=5s
+goos: darwin
+goarch: amd64
+pkg: github.com/harpratap/cue-perf-tests
+cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+BenchmarkConjunctionDouble-16    	   17859	    335044 ns/op
+BenchmarkConjunctionSingle-16    	   19837	    287302 ns/op
+PASS
+ok  	github.com/harpratap/cue-perf-tests	25.784s
+```

--- a/conjunctions.go
+++ b/conjunctions.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"fmt"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+)
+
+const conjunctionSchema = `
+#level1: {
+	text1: #level2
+}
+
+#level2: {
+	text2: string
+}
+`
+
+const singleConjunctionVal = `
+v1: #level1 & {
+	text1: text2: "hello"
+}
+
+v2: #level1 & {
+	text1: text2: "hello"
+}
+
+v3: #level1 & {
+	text1: text2: "hello"
+}
+
+v4: #level1 & {
+	text1: text2: "hello"
+}
+
+v5: #level1 & {
+	text1: text2: "hello"
+}
+
+v6: #level1 & {
+	text1: text2: "hello"
+}
+
+v7: #level1 & {
+	text1: text2: "hello"
+}
+
+v8: #level1 & {
+	text1: text2: "hello"
+}
+
+v9: #level1 & {
+	text1: text2: "hello"
+}
+
+v10: #level1 & {
+	text1: text2: "hello"
+}
+`
+
+const doubleConjunctionVal = `
+v1: #level1 & {
+	text1: #level2 & {
+		text2: "hello"
+	}
+}
+
+v2: #level1 & {
+	text1: #level2 & {
+		text2: "hello"
+	}
+}
+
+v3: #level1 & {
+	text1: #level2 & {
+		text2: "hello"
+	}
+}
+
+v4: #level1 & {
+	text1: #level2 & {
+		text2: "hello"
+	}
+}
+
+v5: #level1 & {
+	text1: #level2 & {
+		text2: "hello"
+	}
+}
+
+v6: #level1 & {
+	text1: #level2 & {
+		text2: "hello"
+	}
+}
+
+v7: #level1 & {
+	text1: #level2 & {
+		text2: "hello"
+	}
+}
+
+v8: #level1 & {
+	text1: #level2 & {
+		text2: "hello"
+	}
+}
+
+v9: #level1 & {
+	text1: #level2 & {
+		text2: "hello"
+	}
+}
+
+v10: #level1 & {
+	text1: #level2 & {
+		text2: "hello"
+	}
+}
+`
+
+func conjunctionSingle() {
+	var (
+		c *cue.Context
+		s cue.Value
+		v cue.Value
+	)
+	c = cuecontext.New()
+	s = c.CompileString(conjunctionSchema)
+	v = c.CompileString(singleConjunctionVal, cue.Scope(s))
+	fmt.Sprint(v)
+}
+
+func conjunctionDouble() {
+	var (
+		c *cue.Context
+		s cue.Value
+		v cue.Value
+	)
+	c = cuecontext.New()
+	s = c.CompileString(conjunctionSchema)
+	v = c.CompileString(doubleConjunctionVal, cue.Scope(s))
+	fmt.Sprint(v)
+}

--- a/conjunctions_test.go
+++ b/conjunctions_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"testing"
+)
+
+func BenchmarkConjunctionDouble(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		conjunctionDouble()
+	}
+}
+
+func BenchmarkConjunctionSingle(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		conjunctionSingle()
+	}
+}

--- a/main.go
+++ b/main.go
@@ -5,4 +5,6 @@ func main() {
 	listComprehensionLong1()
 	listComprehensionShort10()
 	listComprehensionShort10()
+	conjunctionSingle()
+	conjunctionDouble()
 }


### PR DESCRIPTION
Conjunctions or the meet operator `&` adds slowness, even though the end result is practically the same for such nested definitions. Should avoid doing this when at scale